### PR TITLE
Fix running functional tests with Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>${maven.plugin.surefire.version}</version>
+				<configuration>
+					<testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>
+				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>ch.ethz.rtc.kernel</groupId>


### PR DESCRIPTION
Running Maven, the functional tests were not found. Maven's surefire plugin claimed there are ```No tests to run```.
The problem is in the Maven compiler's inability to differentiate between the DNC source directory and the functional tests' source directory. See this log here:

```
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @NetCal-DNC ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 158 source files to /Users/sbondorf/Desktop/workspace/DNC/target/classes

[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @NetCal-DNC ---
[INFO] Nothing to compile - all classes are up to date

[INFO] --- maven-surefire-plugin:2.22.1:test (default-test) @ NetCal-DNC---
[INFO] No tests to run.
```

Adding a configuration to the surefire plugin solves this problem.
However, the obvious
	```<testSourceDirectory>src/functional_tests/java</testSourceDirectory>```
did not work.
Instead, we now tell surefire that the tests are in the build directory and that it has to find them
	```<testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>```