### PR TITLE
ServerGraph: adding a one-hop flow with alias.

### DIFF
--- a/src/main/java/org/networkcalculus/dnc/network/server_graph/ServerGraph.java
+++ b/src/main/java/org/networkcalculus/dnc/network/server_graph/ServerGraph.java
@@ -568,7 +568,7 @@ public class ServerGraph {
 	 */
 	public Flow addFlow(String alias, ArrivalCurve arrival_curve, Server source, Server sink) throws Exception {
 		if (source == sink) {
-			return addFlow(arrival_curve, sink);
+			return addFlow(alias, arrival_curve, sink);
 		}
 
 		return addFlowToServerGraph(alias, arrival_curve, getShortestPath(source, sink));


### PR DESCRIPTION
I added the (imo) appropriate method call with alias in case we want to add a one-hop flow. Previously, it was ignoring the user-defined alias and set it to "fX" with X being the current flow id within the ServerGraph-object. Is it okay like that, or was this a design decision?