### PR TITLE
Fix SFA-FIFO for overloaded servers

### DIFF
--- a/src/main/java/org/networkcalculus/dnc/algebra/disco/con_pw_affine/Deconvolution_Disco_ConPwAffine.java
+++ b/src/main/java/org/networkcalculus/dnc/algebra/disco/con_pw_affine/Deconvolution_Disco_ConPwAffine.java
@@ -390,6 +390,11 @@ public abstract class Deconvolution_Disco_ConPwAffine {
         // With the given assumptions:
         // Output arrival curve is simply a token bucket one: output rate = curve_1.rate and output burst = curve_1.burst + curve_2.latency * curve_1.rate
 
+        if(curve_1.isDelayedInfiniteBurst() ||  curve_2.equals(Curve_ConstantPool.ZERO_SERVICE_CURVE.get()) )
+        {
+            return Curve.getFactory().createArrivalCurve((Curve)Curve_ConstantPool.INFINITE_ARRIVAL_CURVE.get());
+        }
+
         Num ac_burst = curve_1.getBurst();
         Num ac_rate = curve_1.getUltAffineRate();
         Num output_burst = Num.getUtils(Calculator.getInstance().getNumBackend()).mult( curve_2.getLatency(), ac_rate);
@@ -399,6 +404,5 @@ public abstract class Deconvolution_Disco_ConPwAffine {
         ArrivalCurve output_ac = Curve.getFactory().createTokenBucket(ac_rate, output_burst);
 
         return output_ac;
-
     }
 }

--- a/src/main/java/org/networkcalculus/dnc/algebra/disco/pw_affine/Convolution_Disco_PwAffine.java
+++ b/src/main/java/org/networkcalculus/dnc/algebra/disco/pw_affine/Convolution_Disco_PwAffine.java
@@ -74,6 +74,11 @@ public abstract class Convolution_Disco_PwAffine {
             default:
         }
 
+        if(service_curve_0.equals(Curve_ConstantPool.ZERO_SERVICE_CURVE.get())||service_curve_1.equals(Curve_ConstantPool.ZERO_SERVICE_CURVE.get()))
+        {
+            return Curve_ConstantPool.ZERO_SERVICE_CURVE.get();
+        }
+
         ServiceCurve[] service_curves = {service_curve_0.copy(), service_curve_1.copy()};
         int[] i = {0, 0};
 

--- a/src/main/java/org/networkcalculus/dnc/bounds/disco/pw_affine/LeftOverService_Disco_PwAffine.java
+++ b/src/main/java/org/networkcalculus/dnc/bounds/disco/pw_affine/LeftOverService_Disco_PwAffine.java
@@ -131,6 +131,11 @@ public final class LeftOverService_Disco_PwAffine {
     // The FIFO left-over service curve which we get for a specific shift of the arrival curve
     public static ServiceCurve fifoMux(ServiceCurve service_curve, ArrivalCurve arrival_curve, Num theta) {
 
+        if(arrival_curve.isDelayedInfiniteBurst() || service_curve.equals(Curve_ConstantPool.ZERO_SERVICE_CURVE.get()))
+        {
+            return Curve_ConstantPool.ZERO_SERVICE_CURVE.get();
+        }
+
         if(theta.ltZero())
         {
             System.err.println(theta);
@@ -144,7 +149,7 @@ public final class LeftOverService_Disco_PwAffine {
 
 
             ServiceCurve sc_transform = Curve.getFactory().createZeroService(); // zero until theta, after that "copy" of service_curve
-            int sc_transform_curr_seg = 1; // createZeroService creates one segment starting at ursprung with slope 0
+            int sc_transform_curr_seg = 1; // createZeroService creates one segment starting at origin with slope 0
             boolean copy = false; // to distinguish if we have to copy or set sc_transform to zero
             int nrsegs = service_curve.getSegmentCount();
 

--- a/src/main/java/org/networkcalculus/dnc/feedforward/arrivalbounds/AggregatePboo_Concatenation.java
+++ b/src/main/java/org/networkcalculus/dnc/feedforward/arrivalbounds/AggregatePboo_Concatenation.java
@@ -129,6 +129,10 @@ public class AggregatePboo_Concatenation extends AbstractArrivalBound implements
 			Set<ArrivalCurve> alphas_xxfcaller_s = new HashSet<ArrivalCurve>();
 			for (ArrivalCurve arrival_curve_path : alpha_xxfcaller_path) {
 				for (ArrivalCurve arrival_curve_offpath : alpha_xxfcaller_offpath) {
+					if(arrival_curve_offpath.isDelayedInfiniteBurst() || arrival_curve_path.isDelayedInfiniteBurst())
+					{
+						continue;
+					}
 					alphas_xxfcaller_s.add(Curve.getUtils().add(arrival_curve_path, arrival_curve_offpath));
 				}
 			}
@@ -143,7 +147,7 @@ public class AggregatePboo_Concatenation extends AbstractArrivalBound implements
 				System.out.println("No service left over during PBOO arrival bounding!");
 				alphas_xfcaller.clear();
 				alphas_xfcaller.add(Curve.getFactory()
-						.createArrivalCurve((Curve)Curve_ConstantPool.INFINITE_SERVICE_CURVE.get()));
+						.createArrivalCurve((Curve)Curve_ConstantPool.INFINITE_ARRIVAL_CURVE.get()));
 				return alphas_xfcaller;
 			}
 
@@ -189,7 +193,6 @@ public class AggregatePboo_Concatenation extends AbstractArrivalBound implements
 				System.out.println("INFO: Capping output burstiness was not executed as it currently only works for DISCO_AFFINE curves.");
 			}
 		}
-
 		return alphas_xfcaller;
 	}
 }


### PR DESCRIPTION
- Return Infinite Delay Bounds for the foi in case the SFA-FIFO analysis encounters overloaded servers